### PR TITLE
Remove deprecated action buttons

### DIFF
--- a/docs/ui-cleanup.md
+++ b/docs/ui-cleanup.md
@@ -1,0 +1,5 @@
+# UI Cleanup Summary
+
+- Took out the "View Output", "Pull Prices", and "Batch Clean" buttons from the Actions box.
+- Removed the React code that used to run when those buttons were clicked.
+- Left all purchase order and invoice processing code as it was.

--- a/src/components/action-buttons.tsx
+++ b/src/components/action-buttons.tsx
@@ -6,9 +6,6 @@ import { Loader2 } from 'lucide-react';
 interface ActionButtonsProps {
   onImport: () => void;
   onProcess: () => void;
-  onViewOutput: () => void;
-  onPullPrices: () => void;
-  onBatchClean: () => void;
   isProcessing: boolean;
   hasFiles: boolean;
 }
@@ -16,26 +13,23 @@ interface ActionButtonsProps {
 const ActionButtons: React.FC<ActionButtonsProps> = ({
   onImport,
   onProcess,
-  onViewOutput,
-  //onPullPrices,
-  //onBatchClean,
   isProcessing,
   hasFiles,
 }) => {
   return (
     <div className="bg-white rounded-lg shadow-md p-5">
       <h2 className="text-lg font-semibold text-gray-800 mb-4">Actions</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        <Button 
-          variant="outline" 
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-2 gap-3">
+        <Button
+          variant="outline"
           onClick={onImport}
           disabled={isProcessing}
         >
           Import Files
         </Button>
-        
-        <Button 
-          onClick={onProcess} 
+
+        <Button
+          onClick={onProcess}
           disabled={!hasFiles || isProcessing}
           className="bg-primary hover:bg-primary/90"
         >
@@ -47,30 +41,6 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({
           ) : (
             'Process Files'
           )}
-        </Button>
-        
-        <Button 
-          variant="secondary" 
-          onClick={onViewOutput}
-          disabled={isProcessing}
-        >
-          View Output
-        </Button>
-        
-        <Button 
-          variant="outline" 
-          //onClick={onPullPrices}
-          disabled={isProcessing}
-        >
-          Pull Prices
-        </Button>
-        
-        <Button 
-          variant="outline" 
-          //onClick={onBatchClean}
-          disabled={isProcessing}
-        >
-          Batch Clean
         </Button>
       </div>
     </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,9 +17,7 @@ import {
   generateExcelOutput,
   aggregateInvoiceData,
   DocumentType,
-  InvoiceData,
-  //pullPrices as pullPricesService,
-  //batchClean as batchCleanService
+  InvoiceData
 } from '@/services/document-processor';
 
 const Index: React.FC = () => {
@@ -224,56 +222,6 @@ const Index: React.FC = () => {
     document.getElementById('file-input')?.click();
   };
 
-  const handleViewOutput = () => {
-    // In a real app, this would open the output folder
-    // Here we'll just show a toast
-    toast.info("View Output", {
-      description: "In a production environment, this would open the output folder.",
-    });
-  };
-
-  const handlePullPrices = async () => {
-  //   setStatus('processing');
-  //   setStatusMessage('Pulling prices from database...');
-  //   setProgress(50);
-  //   
-  //   try {
-  //     await pullPricesService();
-  //     setStatus('success');
-  //     setStatusMessage('Price data successfully updated');
-  //     toast.success("Prices Updated", {
-  //       description: "Successfully pulled and updated price data",
-  //     });
-  //   } catch (error) {
-  //     setStatus('error');
-  //     setStatusMessage(`Error pulling prices: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  //     toast.error("Error", {
-  //       description: "Failed to pull price data",
-  //     });
-  //   }
-   };
-
-  const handleBatchClean = async () => {
-  //   setStatus('processing');
-  //   setStatusMessage('Running batch clean process...');
-  //   setProgress(50);
-  //   
-  //   try {
-  //     await batchCleanService();
-  //     setStatus('success');
-  //     setStatusMessage('Batch clean completed successfully');
-  //     toast.success("Batch Clean", {
-  //       description: "Successfully completed batch clean process",
-  //     });
-  //   } catch (error) {
-  //     setStatus('error');
-  //     setStatusMessage(`Error during batch clean: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  //     toast.error("Error", {
-  //       description: "Failed to complete batch clean process",
-  //     });
-  //   }
-  };
-
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       <Header />
@@ -298,12 +246,9 @@ const Index: React.FC = () => {
               progress={progress} 
             />
             
-            <ActionButtons 
+            <ActionButtons
               onImport={handleImport}
               onProcess={handleProcess}
-              onViewOutput={handleViewOutput}
-              onPullPrices={handlePullPrices}
-              onBatchClean={handleBatchClean}
               isProcessing={status === 'processing'}
               hasFiles={files.length > 0}
             />


### PR DESCRIPTION
## Summary
- remove the View Output, Pull Prices, and Batch Clean buttons from the shared action bar
- drop the unused handlers from the Index page so only import and process actions remain
- document the cleanup work in docs/ui-cleanup.md for future reference

## Testing
- not run (per user request)


------
https://chatgpt.com/codex/tasks/task_e_68cd8dcff0388333bbc3e9e2691cca80